### PR TITLE
Fix: format sql, other add affected

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,6 +2,7 @@ package gormzap
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/jinzhu/gorm"
@@ -40,7 +41,8 @@ func createLog(values []interface{}) *log {
 		if level == "sql" {
 			ret.duration = getDuration(values)
 			ret.values = getFormattedValues(values)
-			ret.sql = values[3].(string)
+			ret.sql = getFormatSQL(values, ret.values)
+			ret.other = append(ret.other, strconv.FormatInt(values[5].(int64), 10)+" rows affected or returned ")
 		} else {
 			ret.other = append(ret.other, fmt.Sprint(values[2:]))
 		}


### PR DESCRIPTION
hi, I formatted sql, add information that affected to other. the modified idea is at https://github.com/jinzhu/gorm/blob/master/logger.go#L91

log example:
```
{"occurredAt": "2018-11-13T13:53:00.001+0800", "source": "path/file.go:65", "duration": "1.174115ms", "sql": "SELECT * FROM \"rooms\"  ", "values": [], "other": ["43 rows affected or returned "]}
```